### PR TITLE
Add GEOJSON template example

### DIFF
--- a/docs/geojson_template.geojson
+++ b/docs/geojson_template.geojson
@@ -1,0 +1,23 @@
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-122.4194, 37.7749]
+  },
+  "properties": {
+    "id": "event_20250721_001",
+    "timestamp": "2025-07-21T10:30:00Z",
+    "location_name": "San Francisco, CA",
+    "source_type": "flight_tracking",
+    "event_type": "aircraft_loop",
+    "tags": ["ice_cream", "high_altitude", "repeat_event"],
+    "confidence": 0.87,
+    "overlap_score": 2,
+    "description": "Repeat flight circling detention corridor with matched permit activity within 24 hrs.",
+    "data_source": "adsbexchange",
+    "source_link": "https://adsbexchange.com/event?id=20250721_001",
+    "related_entities": ["Target Hospitality", "CoreCivic"],
+    "notes": "Matched prior RSS feed item for local contractor hiring + municipal permit issued same day.",
+    "reviewed": false
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
 <body>
     <h1>Open Radar Map</h1>
     <button class="download-btn" onclick="window.location='flagged_last_7_days.geojson'">Download last 7 days flagged entries</button>
+    <button class="download-btn" onclick="window.location='geojson_template.geojson'">Download GEOJSON template</button>
     <div id="map"></div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- add a downloadable GEOJSON template example to `docs`
- link to the template from the map page

## Testing
- `python -m py_compile ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_687e72fe3b50832fbcec00f92285f1c7