### PR TITLE
Add ingest CI workflow using GitHub secrets

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,0 +1,33 @@
+name: Ingest data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run ingestion
+        env:
+          FLIGHT_DATA_URL: ${{ secrets.FLIGHT_DATA_URL }}
+          PERMIT_DATA_URL: ${{ secrets.PERMIT_DATA_URL }}
+        run: python ingest.py
+      - name: Commit results
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add data docs
+          if git diff --cached --quiet; then
+            echo 'No changes to commit'
+          else
+            git commit -m 'Update data via ingest workflow'
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ v.in.csv input=data/events.csv x=longitude y=latitude output=events
 
 GeoJSON outputs can be imported with `v.import` if the GDAL library is available.
 
+## Automated ingestion with GitHub Actions
+
+The repository includes a workflow that runs `ingest.py` on a schedule. The
+workflow expects two secrets to be defined in the repository settings:
+
+* `FLIGHT_DATA_URL` – private endpoint for flight data
+* `PERMIT_DATA_URL` – private endpoint for permit data
+
+These secrets are exposed as environment variables during the run so that the
+placeholders in `config.yaml` can be resolved. The workflow installs the Python
+dependencies, executes the ingestion script, and commits any updated GeoJSON or
+CSV files back to the repository.
+
+You can also trigger the job manually from the "Actions" tab.
+

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 sources:
   rss: ["https://example.com/feed1.xml", "https://example.com/feed2.xml"]
-  flight_data: "https://public-api.adsbexchange.com"
-  permit_data: "https://city.gov/permit/feed"
+  flight_data: "${FLIGHT_DATA_URL}"
+  permit_data: "${PERMIT_DATA_URL}"
 
 temporal_window_hours: 48
 geojson_output: "./data/geojson/merged_events.geojson"


### PR DESCRIPTION
## Summary
- expand environment variables when loading `config.yaml`
- reference `${FLIGHT_DATA_URL}` and `${PERMIT_DATA_URL}` in `config.yaml`
- document GitHub Actions workflow in README
- add scheduled ingest workflow that commits updated data

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile ingest.py`
- `FLIGHT_DATA_URL='https://example.org/flight' PERMIT_DATA_URL='https://example.org/permit' python ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_687e7ea34ba8832f85d9fabddfa5733f