### PR TITLE
Add test log for troubleshooting

### DIFF
--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,0 +1,22 @@
+## Test Log for open-radar
+
+### Setup
+- Installed requirements with `pip install -r requirements.txt`. Packages installed successfully.
+
+### Running ingest.py
+- Executed `python ingest.py`.
+- No data was downloaded because sources in `config.yaml` point to placeholder URLs. Network requests to `example.com` were blocked by environment policy.
+- The script created empty output files under `data/` and printed "Ingestion complete.". Deprecation warnings were shown for `datetime.utcnow()`.
+
+### Running API server
+- Started the FastAPI app using `uvicorn server:app`.
+- Requested `/download/public` which returned a 500 error because `/tmp/public.geojson` does not exist. Log excerpt:
+
+```
+RuntimeError: File at path /tmp/public.geojson does not exist.
+```
+
+### Observations
+- `server.py` expects files under `/tmp/` that are never written by `ingest.py`, causing the download endpoints to fail.
+- Using `datetime.utcnow()` triggers deprecation warnings; consider timezone-aware datetimes.
+- Network requests to placeholder endpoints are blocked, so example data must be provided locally or via allowed URLs for testing.


### PR DESCRIPTION
## Summary
- run ingest and server to ensure repo runs with default config
- capture errors from API server when data files are missing

## Testing
- `pip install -r requirements.txt`
- `python ingest.py`
- `python -m uvicorn server:app` *(fails: File at path /tmp/public.geojson does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687eb0e5e9ec832fa8623dc5b48fb402