### PR TITLE
Implement radar data pipeline and Streamlit dashboard

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,8 @@
 sources:
   rss: ["https://example.com/feed1.xml", "https://example.com/feed2.xml"]
-  flight_data: "${FLIGHT_DATA_URL}"
-  permit_data: "${PERMIT_DATA_URL}"
-
-temporal_window_hours: 48
-geojson_output: "./data/geojson/merged_events.geojson"
-csv_output: "./data/events.csv"
+  json: []
 duckdb_path: "./data/events.db"
+sqlite_path: "./data/articles.db"
+vault_path: "./vault"
+geojson_output: "./data/geojson/events.geojson"
+csv_output: "./data/events.csv"

--- a/ingest.py
+++ b/ingest.py
@@ -1,260 +1,96 @@
-"""Ingest RSS, flight data, and permit data; output GeoJSON and flagged zones."""
-import json
-import os
-from datetime import datetime, timedelta
-from typing import List, Dict, Any
+"""Ingestion pipeline for Open Radar."""
+from __future__ import annotations
 
-import duckdb
-import feedparser
-import pandas as pd
-import requests
-import yaml
-from dateutil import parser as date_parser
+import argparse
+from datetime import datetime
+from typing import Any, Dict, List
 
-CONFIG_FILE = 'config.yaml'
+import pandas as pd  # type: ignore[import-untyped]
+import yaml  # type: ignore[import-untyped]
 
-def _resolve_env(obj: Any) -> Any:
-    """Recursively expand environment variables in strings."""
-    if isinstance(obj, dict):
-        return {k: _resolve_env(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_resolve_env(v) for v in obj]
-    if isinstance(obj, str):
-        return os.path.expandvars(obj)
-    return obj
+from radar import sources, extract, geocode, dedupe, store, export
 
 
-def load_config(path: str) -> Dict:
-    with open(path, 'r') as f:
-        data = yaml.safe_load(f)
-    return _resolve_env(data)
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
 
-def init_db(db_path: str) -> duckdb.DuckDBPyConnection:
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
-    conn = duckdb.connect(db_path)
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS events (
-            id BIGINT,
-            source_type TEXT,
-            title TEXT,
-            link TEXT,
-            description TEXT,
-            event_time TIMESTAMP,
-            latitude DOUBLE,
-            longitude DOUBLE
-        )
-        """
-    )
-    return conn
+def pull_sources(cfg: Dict[str, Any]) -> List[sources.Item]:
+    items: List[sources.Item] = []
+    items.extend(sources.fetch_rss(cfg.get("sources", {}).get("rss", [])))
+    for url in cfg.get("sources", {}).get("json", []):
+        items.extend(sources.fetch_json(url))
+    return items
 
 
-def parse_rss(url: str) -> List[Dict]:
-    entries = []
-    feed = feedparser.parse(url)
-    for entry in feed.entries:
-        lat = entry.get('geo_lat') or entry.get('lat')
-        lon = entry.get('geo_long') or entry.get('lon')
-        if lat and lon:
-            point = (float(lat), float(lon))
-        else:
-            point = (None, None)
-        dt = entry.get('published') or entry.get('updated')
-        try:
-            dt_parsed = date_parser.parse(dt) if dt else datetime.utcnow()
-        except Exception:
-            dt_parsed = datetime.utcnow()
-        entries.append({
-            'source_type': 'rss',
-            'title': entry.get('title'),
-            'link': entry.get('link'),
-            'description': entry.get('summary'),
-            'event_time': dt_parsed,
-            'latitude': point[0],
-            'longitude': point[1]
-        })
-    return entries
-
-
-def fetch_json(url: str) -> List[Dict]:
-    try:
-        r = requests.get(url, timeout=10)
-        r.raise_for_status()
-        return r.json()
-    except Exception:
-        return []
-
-
-def parse_flights(url: str) -> List[Dict]:
-    data = fetch_json(url)
-    entries = []
-    for item in data if isinstance(data, list) else data.get('flights', []):
-        lat = item.get('lat') or item.get('latitude')
-        lon = item.get('lon') or item.get('longitude')
-        if lat and lon:
-            dt = item.get('timestamp') or item.get('time')
-            try:
-                dt_parsed = date_parser.parse(dt) if isinstance(dt, str) else datetime.utcfromtimestamp(dt)
-            except Exception:
-                dt_parsed = datetime.utcnow()
-            entries.append({
-                'source_type': 'flight',
-                'title': item.get('ident') or 'Flight',
-                'link': '',
-                'description': json.dumps(item),
-                'event_time': dt_parsed,
-                'latitude': float(lat),
-                'longitude': float(lon)
-            })
-    return entries
-
-
-def parse_permits(url: str) -> List[Dict]:
-    data = fetch_json(url)
-    entries = []
-    for item in data if isinstance(data, list) else data.get('permits', []):
-        lat = item.get('lat') or item.get('latitude')
-        lon = item.get('lon') or item.get('longitude')
-        if lat and lon:
-            dt = item.get('date') or item.get('timestamp')
-            try:
-                dt_parsed = date_parser.parse(dt) if isinstance(dt, str) else datetime.utcfromtimestamp(dt)
-            except Exception:
-                dt_parsed = datetime.utcnow()
-            entries.append({
-                'source_type': 'permit',
-                'title': item.get('name') or 'Permit',
-                'link': '',
-                'description': json.dumps(item),
-                'event_time': dt_parsed,
-                'latitude': float(lat),
-                'longitude': float(lon)
-            })
-    return entries
-
-
-def insert_events(conn: duckdb.DuckDBPyConnection, rows: List[Dict]):
-    if not rows:
-        return
-    df = pd.DataFrame(rows)
-    start_id = conn.execute("SELECT COALESCE(MAX(id), 0) + 1 FROM events").fetchone()[0]
-    df.insert(0, 'id', range(start_id, start_id + len(df)))
-    conn.executemany(
-        "INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        df.values.tolist()
-    )
-
-
-def load_data(cfg: Dict, conn: duckdb.DuckDBPyConnection):
-    for feed in cfg['sources'].get('rss', []):
-        insert_events(conn, parse_rss(feed))
-    flight_url = cfg['sources'].get('flight_data')
-    if flight_url:
-        insert_events(conn, parse_flights(flight_url))
-    permit_url = cfg['sources'].get('permit_data')
-    if permit_url:
-        insert_events(conn, parse_permits(permit_url))
-
-
-def export_geojson(conn: duckdb.DuckDBPyConnection, out_path: str):
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
-    rows = conn.execute("SELECT * FROM events").fetchdf()
-    features = []
-    for _, row in rows.iterrows():
-        if row['latitude'] is None or row['longitude'] is None:
+def process_items(items: List[sources.Item], cfg: Dict[str, Any], since: datetime | None) -> List[Dict[str, Any]]:
+    geocoder = geocode.GeoCoder(cfg.get("geocode_cache", "geocode_cache.sqlite"))
+    events: List[Dict[str, Any]] = []
+    for item in items:
+        text = sources.fetch_article_html(item.link) or item.summary
+        candidates = extract.extract_candidates(text, item.title)
+        location_text = candidates[0].text if candidates else ""
+        event_time = extract.extract_event_time(item.published or item.summary)
+        if since and event_time < since:
             continue
-        geom = {
-            'type': 'Point',
-            'coordinates': [row['longitude'], row['latitude']]
-        }
-        props = {
-            'id': int(row['id']),
-            'source_type': row['source_type'],
-            'title': row['title'],
-            'description': row['description'],
-            'link': row['link'],
-            'event_time': row['event_time'].isoformat()
-        }
-        features.append({'type': 'Feature', 'geometry': geom, 'properties': props})
-    with open(out_path, 'w') as f:
-        json.dump({'type': 'FeatureCollection', 'features': features}, f)
+        event_type = extract.classify_event_type(f"{item.title} {item.summary}")
+        simhash = dedupe.simhash_of(item.title + item.summary)
+        if dedupe.is_dupe(simhash, window_hours=24):
+            continue
+        lat, lon, _ = geocoder.geocode(location_text) if location_text else (None, None, None)
+        events.append(
+            {
+                "source": item.source,
+                "title": item.title,
+                "link": item.link,
+                "summary": item.summary,
+                "event_time": event_time,
+                "lat": lat,
+                "lon": lon,
+                "event_type": event_type,
+                "city": None,
+                "state": None,
+                "country": None,
+                "simhash": simhash,
+            }
+        )
+    return events
 
 
-def export_csv(conn: duckdb.DuckDBPyConnection, out_path: str):
-    """Export events to a simple CSV for easy import in tools like GRASS."""
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
-    df = conn.execute("SELECT * FROM events").fetchdf()
-    if df.empty:
-        df.to_csv(out_path, index=False)
+def run_pipeline(cfg: Dict[str, Any], dry_run: bool, since: datetime | None) -> None:
+    items = pull_sources(cfg)
+    events = process_items(items, cfg, since)
+    if dry_run:
+        print(f"Pulled {len(items)} items, {len(events)} events")
         return
-    df.to_csv(out_path, index=False)
+    duck = store.connect_duckdb(cfg["duckdb_path"])
+    sqlite_conn = store.connect_sqlite(cfg["sqlite_path"])
+    ids = store.insert_events(duck, events)
+    for id_, ev in zip(ids, events):
+        store.upsert_article(sqlite_conn, id_, ev["title"], ev["summary"])
+        if cfg.get("vault_path"):
+            export.to_obsidian_note(pd.Series(ev | {"id": id_}), cfg["vault_path"])
+    df = duck.execute("SELECT * FROM events").fetchdf()
+    export.to_geojson(df, cfg["geojson_output"])
+    export.to_csv(df, cfg["csv_output"])
 
 
-def export_flagged(conn: duckdb.DuckDBPyConnection, cfg: Dict, docs_dir: str):
-    temporal_window = cfg.get('temporal_window_hours', 48)
-    window_start = datetime.utcnow() - timedelta(hours=temporal_window)
-    query = f"""
-        SELECT round(latitude, 3) AS lat_round,
-               round(longitude, 3) AS lon_round,
-               list(distinct source_type) as sources,
-               count(*) as count,
-               min(event_time) as first_event_time
-        FROM events
-        WHERE event_time >= '{window_start.isoformat()}'
-          AND latitude IS NOT NULL AND longitude IS NOT NULL
-        GROUP BY lat_round, lon_round
-        HAVING count(distinct source_type) > 2
-    """
-    df = conn.execute(query).fetchdf()
-    features = []
-    for _, row in df.iterrows():
-        geom = {
-            'type': 'Point',
-            'coordinates': [float(row['lon_round']), float(row['lat_round'])]
-        }
-        props = {
-            'sources': row['sources'],
-            'count': int(row['count']),
-            'first_event_time': row['first_event_time'].isoformat()
-        }
-        features.append({'type': 'Feature', 'geometry': geom, 'properties': props})
-
-    os.makedirs(docs_dir, exist_ok=True)
-    flagged_path = os.path.join(docs_dir, 'flagged_zones.geojson')
-    with open(flagged_path, 'w') as f:
-        json.dump({'type': 'FeatureCollection', 'features': features}, f)
-
-    # Export last 7 days of flagged entries
-    seven_days_ago = datetime.utcnow() - timedelta(days=7)
-    df7 = df[df['first_event_time'] >= seven_days_ago]
-    features7 = []
-    for _, row in df7.iterrows():
-        geom = {
-            'type': 'Point',
-            'coordinates': [float(row['lon_round']), float(row['lat_round'])]
-        }
-        props = {
-            'sources': row['sources'],
-            'count': int(row['count']),
-            'first_event_time': row['first_event_time'].isoformat()
-        }
-        features7.append({'type': 'Feature', 'geometry': geom, 'properties': props})
-    out7 = os.path.join(docs_dir, 'flagged_last_7_days.geojson')
-    with open(out7, 'w') as f:
-        json.dump({'type': 'FeatureCollection', 'features': features7}, f)
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--config", default="config.yaml")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--since")
+    p.add_argument("--update", action="store_true", help="Run update pipeline")
+    return p.parse_args()
 
 
-def main():
-    cfg = load_config(CONFIG_FILE)
-    conn = init_db(cfg['duckdb_path'])
-    load_data(cfg, conn)
-    export_geojson(conn, cfg['geojson_output'])
-    if cfg.get('csv_output'):
-        export_csv(conn, cfg['csv_output'])
-    export_flagged(conn, cfg, docs_dir='docs')
-    print('Ingestion complete.')
+def main() -> None:
+    args = parse_args()
+    cfg = load_config(args.config)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    run_pipeline(cfg, args.dry_run, since)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/radar/dedupe.py
+++ b/radar/dedupe.py
@@ -1,0 +1,30 @@
+"""Duplicate detection using simhash."""
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Deque, Tuple
+
+try:  # pragma: no cover - dependency optional
+    from simhash import Simhash  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover
+    class Simhash:  # type: ignore[no-redef]
+        def __init__(self, text: str):
+            self.value = hash(text)
+
+_seen: Deque[Tuple[int, datetime]] = deque()
+
+
+def simhash_of(text: str) -> int:
+    return Simhash(text).value
+
+
+def is_dupe(simhash: int, window_hours: int = 24) -> bool:
+    cutoff = datetime.utcnow() - timedelta(hours=window_hours)
+    while _seen and _seen[0][1] < cutoff:
+        _seen.popleft()
+    for h, _ in _seen:
+        if h == simhash:
+            return True
+    _seen.append((simhash, datetime.utcnow()))
+    return False

--- a/radar/export.py
+++ b/radar/export.py
@@ -1,0 +1,61 @@
+"""Export helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import pandas as pd  # type: ignore[import-untyped]
+
+
+def to_geojson(df: pd.DataFrame, path: str) -> None:
+    features = []
+    for _, row in df.iterrows():
+        if pd.isna(row.get("lat")) or pd.isna(row.get("lon")):
+            continue
+        props = row.to_dict()
+        if isinstance(props.get("event_time"), pd.Timestamp):
+            props["event_time"] = str(props["event_time"])
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [row["lon"], row["lat"]],
+                },
+                "properties": props,
+            }
+        )
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump({"type": "FeatureCollection", "features": features}, f)
+
+
+def to_csv(df: pd.DataFrame, path: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def to_obsidian_note(row: pd.Series, vault_path: str) -> Path:
+    date = pd.to_datetime(row["event_time"]).date()
+    directory = Path(vault_path) / "News" / "Events" / str(date)
+    directory.mkdir(parents=True, exist_ok=True)
+    slug = "".join(c for c in row["title"] if c.isalnum() or c in (" ", "-"))[:50].strip().replace(" ", "-")
+    note_path = directory / f"{slug}.md"
+    frontmatter = {
+        "title": row["title"],
+        "source": row["source"],
+        "link": row["link"],
+        "event_time": str(row["event_time"]),
+        "lat": row.get("lat"),
+        "lon": row.get("lon"),
+        "event_type": row.get("event_type"),
+        "city": row.get("city"),
+        "state": row.get("state"),
+        "country": row.get("country"),
+    }
+    with open(note_path, "w") as f:
+        f.write("---\n")
+        for k, v in frontmatter.items():
+            f.write(f"{k}: {v}\n")
+        f.write("---\n\n")
+        f.write(str(row.get("summary", "")))
+    return note_path

--- a/radar/extract.py
+++ b/radar/extract.py
@@ -1,0 +1,89 @@
+"""Text extraction helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+import re
+
+try:  # pragma: no cover - optional deps
+    import dateparser  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover
+    dateparser = None  # type: ignore
+from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
+try:  # pragma: no cover
+    import spacy  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover
+    class _DummyNLP:
+        def __call__(self, _text: str):
+            class _Doc:
+                ents: list = []
+
+            return _Doc()
+
+    class _SpacyModule:
+        def blank(self, _lang: str):  # noqa: D401
+            return _DummyNLP()
+
+    spacy = _SpacyModule()  # type: ignore
+
+
+_nlp: spacy.language.Language | None = None
+
+
+@dataclass
+class Candidate:
+    text: str
+
+
+def load_spacy() -> spacy.language.Language:
+    """Load spaCy model with graceful fallback."""
+    global _nlp
+    if _nlp is None:
+        try:
+            if spacy is None:
+                raise ImportError
+            _nlp = spacy.load("en_core_web_sm")
+        except Exception:  # pragma: no cover - model not installed
+            _nlp = spacy.blank("en")
+    return _nlp
+
+
+def extract_candidates(text: str, title: str = "") -> List[Candidate]:
+    nlp = load_spacy()
+    doc = nlp(f"{title}\n{text}")
+    ents = getattr(doc, "ents", [])
+    if not ents:  # very simple fallback
+        return [Candidate(m) for m in re.findall(r"[A-Z][a-z]+", f"{title} {text}")]
+    return [Candidate(ent.text) for ent in ents if getattr(ent, "label_", "") in {"GPE", "LOC"}]
+
+
+def extract_event_time(meta: str | datetime | None) -> datetime:
+    if isinstance(meta, datetime):
+        return meta
+    if isinstance(meta, str):
+        dt = dateparser.parse(meta) if dateparser else None
+        if not dt:
+            dt = dateutil_parser.parse(meta, fuzzy=True)
+        if dt:
+            return dt
+    return datetime.utcnow()
+
+
+KEYWORDS = [
+    "robbery",
+    "assault",
+    "burglary",
+    "shooting",
+    "fire",
+    "crash",
+    "arrest",
+]
+
+
+def classify_event_type(text: str) -> str:
+    lower = text.lower()
+    for word in KEYWORDS:
+        if word in lower:
+            return word
+    return "other"

--- a/radar/geocode.py
+++ b/radar/geocode.py
@@ -1,0 +1,60 @@
+"""Geocoding with SQLite cache."""
+from __future__ import annotations
+
+from datetime import datetime
+import sqlite3
+import time
+from typing import Tuple
+
+try:  # pragma: no cover - optional
+    from geopy.geocoders import Nominatim  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover
+    Nominatim = None  # type: ignore
+
+
+class GeoCoder:
+    def __init__(self, cache_sqlite_path: str, user_agent: str = "open-radar"):
+        self.conn = sqlite3.connect(cache_sqlite_path)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS geocache (
+                query TEXT PRIMARY KEY,
+                lat REAL,
+                lon REAL,
+                accuracy REAL,
+                ts TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+        if Nominatim is None:
+            class _Dummy:
+                def geocode(self, _query: str):
+                    return None
+
+            self.geocoder = _Dummy()
+        else:
+            self.geocoder = Nominatim(user_agent=user_agent)
+
+    def geocode(self, text: str) -> Tuple[float | None, float | None, float | None]:
+        cur = self.conn.execute("SELECT lat, lon, accuracy FROM geocache WHERE query=?", (text,))
+        row = cur.fetchone()
+        if row:
+            return row
+        time.sleep(1)
+        try:
+            loc = self.geocoder.geocode(text)
+        except Exception:
+            loc = None
+        if loc:
+            lat = loc.latitude
+            lon = loc.longitude
+            accuracy = loc.raw.get("importance") if hasattr(loc, "raw") else None
+        else:
+            lat = lon = accuracy = None
+        self.conn.execute(
+            "INSERT OR REPLACE INTO geocache(query, lat, lon, accuracy, ts) VALUES(?,?,?,?,?)",
+            (text, lat, lon, accuracy, datetime.utcnow()),
+        )
+        self.conn.commit()
+        return lat, lon, accuracy

--- a/radar/sources.py
+++ b/radar/sources.py
@@ -1,0 +1,92 @@
+"""Source fetching utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+import feedparser  # type: ignore[import-untyped]
+import requests  # type: ignore[import-untyped]
+
+
+@dataclass
+class Item:
+    """Normalized feed item."""
+
+    source: str
+    title: str
+    link: str
+    summary: str
+    published: datetime | None
+
+
+def fetch_rss(urls: List[str]) -> List[Item]:
+    """Fetch RSS/Atom feeds and return normalized items."""
+    items: List[Item] = []
+    for url in urls:
+        feed = feedparser.parse(url)
+        for entry in feed.entries:
+            published = None
+            dt = entry.get("published") or entry.get("updated")
+            if dt:
+                try:
+                    published = datetime(*entry.published_parsed[:6])
+                except Exception:
+                    try:
+                        published = datetime(*entry.updated_parsed[:6])
+                    except Exception:  # pragma: no cover - best effort
+                        published = None
+            items.append(
+                Item(
+                    source=url,
+                    title=entry.get("title", ""),
+                    link=entry.get("link", ""),
+                    summary=entry.get("summary", ""),
+                    published=published,
+                )
+            )
+    return items
+
+
+def fetch_json(url: str) -> List[Item]:
+    """Fetch JSON feed with list of items."""
+    items: List[Item] = []
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return items
+    for obj in data if isinstance(data, list) else data.get("items", []):
+        items.append(
+            Item(
+                source=url,
+                title=obj.get("title", ""),
+                link=obj.get("link", ""),
+                summary=obj.get("summary", ""),
+                published=None,
+            )
+        )
+    return items
+
+
+def fetch_article_html(url: str) -> str:
+    """Fetch article HTML, trying trafilatura then newspaper3k."""
+    try:  # pragma: no cover - network heavy
+        import trafilatura  # type: ignore[import-not-found]
+
+        downloaded = trafilatura.fetch_url(url)
+        text = trafilatura.extract(downloaded or "")
+        if text:
+            return text
+    except Exception:
+        pass
+    try:  # pragma: no cover - slow
+        from newspaper import Article  # type: ignore[import-not-found]
+
+        art = Article(url)
+        art.download()
+        art.parse()
+        return art.text
+    except Exception:
+        return ""

--- a/radar/store.py
+++ b/radar/store.py
@@ -1,0 +1,96 @@
+"""Storage helpers for DuckDB and SQLite FTS."""
+from __future__ import annotations
+
+from typing import List, Dict
+import sqlite3
+
+import duckdb  # type: ignore[import-not-found]
+import pandas as pd  # type: ignore[import-untyped]
+
+EVENT_COLUMNS = [
+    "id",
+    "source",
+    "title",
+    "link",
+    "summary",
+    "event_time",
+    "lat",
+    "lon",
+    "event_type",
+    "city",
+    "state",
+    "country",
+    "simhash",
+]
+
+
+def connect_duckdb(path: str) -> duckdb.DuckDBPyConnection:
+    conn = duckdb.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS events (
+            id BIGINT,
+            source TEXT,
+            title TEXT,
+            link TEXT,
+            summary TEXT,
+            event_time TIMESTAMP,
+            lat DOUBLE,
+            lon DOUBLE,
+            event_type TEXT,
+            city TEXT,
+            state TEXT,
+            country TEXT,
+            simhash BIGINT
+        )
+        """
+    )
+    return conn
+
+
+def insert_events(conn: duckdb.DuckDBPyConnection, rows: List[Dict]) -> List[int]:
+    if not rows:
+        return []
+    df = pd.DataFrame(rows, columns=EVENT_COLUMNS[1:])
+    row = conn.execute("SELECT COALESCE(MAX(id), 0) + 1 FROM events").fetchone()
+    start_id = int(row[0]) if row else 1
+    df.insert(0, "id", range(start_id, start_id + len(df)))
+    conn.executemany(
+        "INSERT INTO events VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        df.values.tolist(),
+    )
+    return df["id"].tolist()
+
+
+def connect_sqlite(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS articles (id INTEGER PRIMARY KEY, title TEXT, summary TEXT)"
+    )
+    cur.execute(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(title, summary, content='articles', content_rowid='id')"
+    )
+    conn.commit()
+    return conn
+
+
+def upsert_article(conn: sqlite3.Connection, id_: int, title: str, summary: str) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT OR REPLACE INTO articles(id, title, summary) VALUES(?,?,?)",
+        (id_, title, summary),
+    )
+    cur.execute(
+        "INSERT OR REPLACE INTO articles_fts(rowid, title, summary) VALUES(?,?,?)",
+        (id_, title, summary),
+    )
+    conn.commit()
+
+
+def search_articles(conn: sqlite3.Connection, query: str) -> List[int]:
+    cur = conn.cursor()
+    rows = cur.execute(
+        "SELECT rowid FROM articles_fts WHERE articles_fts MATCH ?", (query,)
+    ).fetchall()
+    return [r[0] for r in rows]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
+duckdb>=1.1.0
 feedparser
-duckdb
-geojson
 pandas
 requests
-flask
-jinja2
+pyyaml
 python-dateutil
-PyYAML
-fastapi
-uvicorn
-python-multipart
+dateparser
+spacy>=3.7
+geopy
+trafilatura
+newspaper3k
+simhash
+streamlit
+# After install run: python -m spacy download en_core_web_sm

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS articles (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    summary TEXT
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
+    title, summary, content='articles', content_rowid='id'
+);

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,18 @@
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+python -m spacy download en_core_web_sm
+
+@"
+sources:
+  rss:
+    - https://news.un.org/feed/subscribe/en/news/all/rss.xml
+  json: []
+duckdb_path: data/events.db
+sqlite_path: data/articles.db
+vault_path: vault
+geojson_output: data/events.geojson
+csv_output: data/events.csv
+"@ | Out-File -Encoding UTF8 config.yaml
+
+python ingest.py --update

--- a/server.py
+++ b/server.py
@@ -1,77 +1,87 @@
-from fastapi import FastAPI, UploadFile, File, Form, Depends, HTTPException
-from fastapi.responses import FileResponse
-from typing import List
-import json
-import os
-import re
+"""Streamlit UI for exploring events."""
+from __future__ import annotations
 
-app = FastAPI()
+import subprocess
+from datetime import datetime
+from pathlib import Path
 
-AUTHORIZED_USERS = {"definitelynotaspren", "trustedadmin1"}
-FLAG_REASONS = [
-    "Unusual activity",
-    "Restricted airspace",
-    "Data anomaly",
-    "Public safety",
-    "Possible privacy concern",
-    "Possible residential address",
-    "Other",
-]
+import duckdb  # type: ignore[import-not-found]
+import pandas as pd  # type: ignore[import-untyped]
+import streamlit as st  # type: ignore[import-not-found]
+import yaml  # type: ignore[import-untyped]
+import pydeck as pdk  # type: ignore[import-not-found]
 
-def get_user(user: str = Form(...)):
-    if user not in AUTHORIZED_USERS:
-        raise HTTPException(status_code=403, detail="Unauthorized")
-    return user
+from radar import export, store
 
-def is_residential_address(address: str) -> bool:
-    return bool(re.search(r"\d+\s+\w+\s+(Ave|Street|St|Rd|Boulevard|Blvd|Ln|Lane|Ct|Court|Dr|Drive)", address, re.I))
 
-@app.post("/ingest")
-async def ingest(
-    user: str = Depends(get_user),
-    files: List[UploadFile] = File([]),
-    urls: str = Form(""),
-    api_key: str = Form(""),
-    flag_reason: str = Form("")
-):
-    output_public = "/tmp/public.geojson"
-    output_private = "/tmp/private.geojson"
-    audit_log_file = "/tmp/audit_log.json"
-    entries_for_audit = []
-    processed_entries = []
+def load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
-    for entry in processed_entries:
-        if flag_reason == "Possible residential address" or is_residential_address(entry.get("address", "")):
-            entries_for_audit.append(entry)
-        else:
-            pass
 
-    if entries_for_audit:
-        with open(audit_log_file, "a") as log:
-            for entry in entries_for_audit:
-                log.write(json.dumps({
-                    "user": user,
-                    "entry": entry,
-                    "flag_reason": flag_reason
-                }) + "\n")
+def load_events(duck_path: str) -> pd.DataFrame:
+    return duckdb.connect(duck_path).execute("SELECT * FROM events").fetchdf()
 
-    return {"public": output_public, "private": output_private, "audit": audit_log_file}
 
-@app.get("/download/public")
-def download_public():
-    return FileResponse("/tmp/public.geojson", media_type="application/json", filename="public.geojson")
+def main() -> None:
+    st.set_page_config(layout="wide")
+    cfg_path = st.sidebar.text_input("Config path", "config.yaml")
+    cfg = load_config(cfg_path)
+    df = load_events(cfg["duckdb_path"])
 
-@app.get("/download/private")
-def download_private(user: str):
-    if user not in AUTHORIZED_USERS:
-        return {"contact": "Request access to private data."}
-    return FileResponse("/tmp/private.geojson", media_type="application/json", filename="private.geojson")
+    # Filters
+    min_date, max_date = df["event_time"].min(), df["event_time"].max()
+    start, end = st.sidebar.date_input("Date range", [min_date, max_date])
+    sources = st.sidebar.multiselect("Source", df["source"].unique())
+    types = st.sidebar.multiselect("Event type", df["event_type"].unique())
+    query = st.sidebar.text_input("Text search")
+    if query:
+        ids = store.search_articles(store.connect_sqlite(cfg["sqlite_path"]), query)
+        df = df[df["id"].isin(ids)]
+    mask = (df["event_time"].dt.date >= start) & (df["event_time"].dt.date <= end)
+    if sources:
+        mask &= df["source"].isin(sources)
+    if types:
+        mask &= df["event_type"].isin(types)
+    df = df[mask]
 
-@app.get("/audit-log")
-def audit_log(user: str):
-    if user not in AUTHORIZED_USERS:
-        raise HTTPException(status_code=403, detail="Unauthorized")
-    if not os.path.exists("/tmp/audit_log.json"):
-        return ""
-    with open("/tmp/audit_log.json") as log:
-        return log.read()
+    # Map
+    st.pydeck_chart(
+        pdk.Deck(
+            map_style="mapbox://styles/mapbox/light-v9",
+            initial_view_state=pdk.ViewState(latitude=0, longitude=0, zoom=2),
+            layers=[
+                pdk.Layer(
+                    "ScatterplotLayer",
+                    data=df,
+                    get_position="[lon, lat]",
+                    get_color="[200, 30, 0, 160]",
+                    get_radius=200,
+                )
+            ],
+        )
+    )
+
+    st.dataframe(df)
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        if st.button("Export GeoJSON"):
+            export.to_geojson(df, cfg.get("geojson_output", "events.geojson"))
+    with col2:
+        if st.button("Export CSV"):
+            export.to_csv(df, cfg.get("csv_output", "events.csv"))
+    with col3:
+        selected = st.multiselect("Select IDs", df["id"].tolist())
+        if st.button("Export to Obsidian") and cfg.get("vault_path"):
+            for _, row in df[df["id"].isin(selected)].iterrows():
+                export.to_obsidian_note(row, cfg["vault_path"])
+
+    st.sidebar.write("Last run:", datetime.fromtimestamp(Path(cfg["duckdb_path"]).stat().st_mtime))
+    if st.sidebar.button("Run update now"):
+        subprocess.run(["python", "ingest.py", "--config", cfg_path, "--update"], check=False)
+        st.experimental_rerun()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/fixtures/rss1.xml
+++ b/tests/fixtures/rss1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<rss><channel>
+  <item>
+    <title>Fire in Paris</title>
+    <link>http://example.com/1</link>
+    <description>Fire broke out in Paris.</description>
+    <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+  </item>
+</channel></rss>

--- a/tests/fixtures/rss2.xml
+++ b/tests/fixtures/rss2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<rss><channel>
+  <item>
+    <title>Robbery in London</title>
+    <link>http://example.com/2</link>
+    <description>Police report a robbery in London.</description>
+    <pubDate>Tue, 02 Jan 2024 00:00:00 GMT</pubDate>
+  </item>
+</channel></rss>

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,7 @@
+from radar import dedupe
+
+
+def test_is_dupe():
+    h = dedupe.simhash_of("test")
+    assert not dedupe.is_dupe(h)
+    assert dedupe.is_dupe(h)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,15 @@
+from radar import extract
+
+
+def test_extract_candidates():
+    cands = extract.extract_candidates("Fire in London", "Fire in London")
+    assert any("London" in c.text for c in cands)
+
+
+def test_extract_event_time():
+    dt = extract.extract_event_time("2024-01-01")
+    assert dt.year == 2024
+
+
+def test_classify_event_type():
+    assert extract.classify_event_type("Reported burglary") == "burglary"

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -1,0 +1,25 @@
+from radar.geocode import GeoCoder
+
+
+class DummyLocation:
+    def __init__(self, lat, lon):
+        self.latitude = lat
+        self.longitude = lon
+        self.raw = {"importance": 0.5}
+
+
+def test_geocode_cache(tmp_path, monkeypatch):
+    gc = GeoCoder(str(tmp_path / "cache.sqlite"), user_agent="test")
+    monkeypatch.setattr(gc.geocoder, "geocode", lambda q: DummyLocation(1.0, 2.0))
+    lat, lon, acc = gc.geocode("Somewhere")
+    assert (lat, lon) == (1.0, 2.0)
+    called = {"count": 0}
+
+    def fail(q):
+        called["count"] += 1
+        raise AssertionError
+
+    monkeypatch.setattr(gc.geocoder, "geocode", fail)
+    lat2, lon2, _ = gc.geocode("Somewhere")
+    assert (lat2, lon2) == (1.0, 2.0)
+    assert called["count"] == 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from radar import sources, geocode
+import ingest
+
+
+def test_ingest_smoke(tmp_path, monkeypatch):
+    rss1 = (Path(__file__).parent / "fixtures/rss1.xml").as_uri()
+    rss2 = (Path(__file__).parent / "fixtures/rss2.xml").as_uri()
+    cfg = {
+        "sources": {"rss": [rss1, rss2], "json": []},
+        "duckdb_path": str(tmp_path / "events.db"),
+        "sqlite_path": str(tmp_path / "articles.db"),
+        "vault_path": str(tmp_path / "vault"),
+        "geojson_output": str(tmp_path / "events.geojson"),
+        "csv_output": str(tmp_path / "events.csv"),
+    }
+    monkeypatch.setattr(sources, "fetch_article_html", lambda url: "")
+    monkeypatch.setattr(geocode.GeoCoder, "geocode", lambda self, text: (0.0, 0.0, 1.0))
+    ingest.run_pipeline(cfg, dry_run=False, since=None)
+    data = json.loads(Path(cfg["geojson_output"]).read_text())
+    assert data["features"]


### PR DESCRIPTION
## Summary
- Add modular `radar` package for source fetching, NLP extraction, geocoding with cache, deduplication, storage and export utilities
- Refactor `ingest.py` pipeline with configurable sources, Obsidian export and CLI flags
- Introduce Streamlit `server.py` for interactive filtering, mapping and on-demand updates; document setup and add tests

## Testing
- `ruff check ingest.py server.py radar tests`
- `mypy ingest.py server.py radar`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896241a1cd4832faad79feb48f8a557