### PR TITLE
overhaul for 26

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -14,20 +14,23 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          python -m spacy download en_core_web_sm
       - name: Run ingestion
         env:
+          POSTGIS_DSN: ${{ secrets.POSTGIS_DSN }}
           FLIGHT_DATA_URL: ${{ secrets.FLIGHT_DATA_URL }}
           PERMIT_DATA_URL: ${{ secrets.PERMIT_DATA_URL }}
         run: python ingest.py
-      - name: Commit results
+      - name: Commit GeoJSON output (if PostGIS not configured)
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add data docs
+          git add data/geojson data/events.csv 2>/dev/null || true
           if git diff --cached --quiet; then
             echo 'No changes to commit'
           else
-            git commit -m 'Update data via ingest workflow'
+            git commit -m 'Update exported data via ingest workflow'
             git push
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+*.egg-info/
+
 # Ignore generated database
 /data/*.db
+/data/*.sqlite
 # Ignore generated geojson files
 /data/geojson/*.geojson
 /data/*.csv

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,17 @@
 sources:
   rss: ["https://example.com/feed1.xml", "https://example.com/feed2.xml"]
   json: []
+
+# PostGIS DSN — set this (or POSTGIS_DSN env var) to enable the live QGIS backend.
+# Example: "postgresql://user:pass@localhost:5432/radar"
+# Leave blank to fall back to DuckDB.
+postgis_dsn: ""
+
+# DuckDB / SQLite fallback paths (used when postgis_dsn is empty)
 duckdb_path: "./data/events.db"
 sqlite_path: "./data/articles.db"
+geocode_cache: "./data/geocode_cache.sqlite"
+
 vault_path: "./vault"
 geojson_output: "./data/geojson/events.geojson"
 csv_output: "./data/events.csv"

--- a/ingest.py
+++ b/ingest.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime
+import hashlib
+import os
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 import pandas as pd  # type: ignore[import-untyped]
@@ -13,19 +15,40 @@ from radar import sources, extract, geocode, dedupe, store, export
 
 def load_config(path: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        raw = yaml.safe_load(f)
+    # Allow env-var overrides for secrets
+    for key in ("postgis_dsn", "flight_data_url", "permit_data_url"):
+        env_val = os.environ.get(key.upper())
+        if env_val:
+            raw[key] = env_val
+    return raw
+
+
+def _event_uid(item: sources.Item) -> str:
+    basis = (item.link or f"{item.title}|{item.published}|{item.source}").strip().lower()
+    return hashlib.sha256(basis.encode()).hexdigest()[:32]
 
 
 def pull_sources(cfg: Dict[str, Any]) -> List[sources.Item]:
     items: List[sources.Item] = []
-    items.extend(sources.fetch_rss(cfg.get("sources", {}).get("rss", [])))
+    rss_urls = cfg.get("sources", {}).get("rss", [])
+    # Allow runtime URL injection from env
+    flight_url = cfg.get("flight_data_url")
+    permit_url = cfg.get("permit_data_url")
+    items.extend(sources.fetch_rss(rss_urls))
     for url in cfg.get("sources", {}).get("json", []):
         items.extend(sources.fetch_json(url))
+    if flight_url:
+        items.extend(sources.fetch_json(flight_url))
+    if permit_url:
+        items.extend(sources.fetch_json(permit_url))
     return items
 
 
-def process_items(items: List[sources.Item], cfg: Dict[str, Any], since: datetime | None) -> List[Dict[str, Any]]:
-    geocoder = geocode.GeoCoder(cfg.get("geocode_cache", "geocode_cache.sqlite"))
+def process_items(
+    items: List[sources.Item], cfg: Dict[str, Any], since: datetime | None
+) -> List[Dict[str, Any]]:
+    geocoder = geocode.GeoCoder(cfg.get("geocode_cache", "data/geocode_cache.sqlite"))
     events: List[Dict[str, Any]] = []
     for item in items:
         text = sources.fetch_article_html(item.link) or item.summary
@@ -35,12 +58,13 @@ def process_items(items: List[sources.Item], cfg: Dict[str, Any], since: datetim
         if since and event_time < since:
             continue
         event_type = extract.classify_event_type(f"{item.title} {item.summary}")
-        simhash = dedupe.simhash_of(item.title + item.summary)
-        if dedupe.is_dupe(simhash, window_hours=24):
+        simhash_val = dedupe.simhash_of(item.title + item.summary)
+        if dedupe.is_dupe(simhash_val, window_hours=24):
             continue
-        lat, lon, _ = geocoder.geocode(location_text) if location_text else (None, None, None)
+        lat, lon, confidence = geocoder.geocode(location_text) if location_text else (None, None, None)
         events.append(
             {
+                "event_uid": _event_uid(item),
                 "source": item.source,
                 "title": item.title,
                 "link": item.link,
@@ -52,7 +76,8 @@ def process_items(items: List[sources.Item], cfg: Dict[str, Any], since: datetim
                 "city": None,
                 "state": None,
                 "country": None,
-                "simhash": simhash,
+                "confidence": confidence,
+                "simhash": simhash_val,
             }
         )
     return events
@@ -62,18 +87,28 @@ def run_pipeline(cfg: Dict[str, Any], dry_run: bool, since: datetime | None) -> 
     items = pull_sources(cfg)
     events = process_items(items, cfg, since)
     if dry_run:
-        print(f"Pulled {len(items)} items, {len(events)} events")
+        print(f"Pulled {len(items)} items, {len(events)} events (dry run — nothing written)")
         return
-    duck = store.connect_duckdb(cfg["duckdb_path"])
-    sqlite_conn = store.connect_sqlite(cfg["sqlite_path"])
-    ids = store.insert_events(duck, events)
-    for id_, ev in zip(ids, events):
-        store.upsert_article(sqlite_conn, id_, ev["title"], ev["summary"])
-        if cfg.get("vault_path"):
-            export.to_obsidian_note(pd.Series(ev | {"id": id_}), cfg["vault_path"])
-    df = duck.execute("SELECT * FROM events").fetchdf()
-    export.to_geojson(df, cfg["geojson_output"])
-    export.to_csv(df, cfg["csv_output"])
+
+    postgis_dsn = cfg.get("postgis_dsn")
+    if postgis_dsn:
+        from radar import pg_store
+        pg_conn = pg_store.connect(postgis_dsn)
+        pg_store.ensure_schema(pg_conn)
+        written = pg_store.upsert_events(pg_conn, events)
+        pg_conn.close()
+        print(f"Upserted {written} events into PostGIS")
+    else:
+        duck = store.connect_duckdb(cfg["duckdb_path"])
+        sqlite_conn = store.connect_sqlite(cfg["sqlite_path"])
+        uids = store.insert_events(duck, events)
+        for uid, ev in zip(uids, events):
+            store.upsert_article(sqlite_conn, uid, ev["title"], ev["summary"])
+            if cfg.get("vault_path"):
+                export.to_obsidian_note(pd.Series(ev | {"id": uid}), cfg["vault_path"])
+        df = duck.execute("SELECT * FROM events").fetchdf()
+        export.to_geojson(df, cfg["geojson_output"])
+        export.to_csv(df, cfg["csv_output"])
 
 
 def parse_args() -> argparse.Namespace:
@@ -88,7 +123,11 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     cfg = load_config(args.config)
-    since = datetime.fromisoformat(args.since) if args.since else None
+    since: datetime | None = None
+    if args.since:
+        since = datetime.fromisoformat(args.since)
+        if since.tzinfo is None:
+            since = since.replace(tzinfo=timezone.utc)
     run_pipeline(cfg, args.dry_run, since)
 
 

--- a/radar/dedupe.py
+++ b/radar/dedupe.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Deque, Tuple
 
 try:  # pragma: no cover - dependency optional
@@ -20,11 +20,12 @@ def simhash_of(text: str) -> int:
 
 
 def is_dupe(simhash: int, window_hours: int = 24) -> bool:
-    cutoff = datetime.utcnow() - timedelta(hours=window_hours)
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=window_hours)
     while _seen and _seen[0][1] < cutoff:
         _seen.popleft()
     for h, _ in _seen:
         if h == simhash:
             return True
-    _seen.append((simhash, datetime.utcnow()))
+    _seen.append((simhash, now))
     return False

--- a/radar/extract.py
+++ b/radar/extract.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 import re
 
@@ -58,16 +58,25 @@ def extract_candidates(text: str, title: str = "") -> List[Candidate]:
     return [Candidate(ent.text) for ent in ents if getattr(ent, "label_", "") in {"GPE", "LOC"}]
 
 
+def _ensure_aware(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def extract_event_time(meta: str | datetime | None) -> datetime:
     if isinstance(meta, datetime):
-        return meta
+        return _ensure_aware(meta)
     if isinstance(meta, str):
-        dt = dateparser.parse(meta) if dateparser else None
+        dt = dateparser.parse(meta, settings={"RETURN_AS_TIMEZONE_AWARE": True}) if dateparser else None
         if not dt:
-            dt = dateutil_parser.parse(meta, fuzzy=True)
+            try:
+                dt = dateutil_parser.parse(meta, fuzzy=True)
+            except Exception:
+                dt = None
         if dt:
-            return dt
-    return datetime.utcnow()
+            return _ensure_aware(dt)
+    return datetime.now(timezone.utc)
 
 
 KEYWORDS = [

--- a/radar/geocode.py
+++ b/radar/geocode.py
@@ -1,7 +1,8 @@
 """Geocoding with SQLite cache."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
 import sqlite3
 import time
 from typing import Tuple
@@ -14,6 +15,7 @@ except Exception:  # pragma: no cover
 
 class GeoCoder:
     def __init__(self, cache_sqlite_path: str, user_agent: str = "open-radar"):
+        Path(cache_sqlite_path).parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(cache_sqlite_path)
         self.conn.execute(
             """
@@ -37,13 +39,14 @@ class GeoCoder:
             self.geocoder = Nominatim(user_agent=user_agent)
 
     def geocode(self, text: str) -> Tuple[float | None, float | None, float | None]:
-        cur = self.conn.execute("SELECT lat, lon, accuracy FROM geocache WHERE query=?", (text,))
+        key = text.strip().casefold()
+        cur = self.conn.execute("SELECT lat, lon, accuracy FROM geocache WHERE query=?", (key,))
         row = cur.fetchone()
         if row:
             return row
         time.sleep(1)
         try:
-            loc = self.geocoder.geocode(text)
+            loc = self.geocoder.geocode(key)
         except Exception:
             loc = None
         if loc:
@@ -54,7 +57,7 @@ class GeoCoder:
             lat = lon = accuracy = None
         self.conn.execute(
             "INSERT OR REPLACE INTO geocache(query, lat, lon, accuracy, ts) VALUES(?,?,?,?,?)",
-            (text, lat, lon, accuracy, datetime.utcnow()),
+            (key, lat, lon, accuracy, datetime.now(timezone.utc)),
         )
         self.conn.commit()
         return lat, lon, accuracy

--- a/radar/pg_store.py
+++ b/radar/pg_store.py
@@ -1,0 +1,74 @@
+"""PostGIS storage backend for idempotent event ingestion."""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+try:
+    import psycopg2  # type: ignore[import-not-found]
+    import psycopg2.extras  # type: ignore[import-not-found]
+except ImportError:
+    psycopg2 = None  # type: ignore
+
+
+SCHEMA_SQL = """
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE IF NOT EXISTS events (
+    event_uid   TEXT PRIMARY KEY,
+    source      TEXT,
+    title       TEXT,
+    link        TEXT,
+    summary     TEXT,
+    event_time  TIMESTAMPTZ,
+    event_type  TEXT,
+    city        TEXT,
+    state       TEXT,
+    country     TEXT,
+    confidence  DOUBLE PRECISION,
+    simhash     NUMERIC(20),
+    first_seen  TIMESTAMPTZ DEFAULT now(),
+    last_seen   TIMESTAMPTZ DEFAULT now(),
+    geom        GEOMETRY(Point, 4326)
+);
+
+CREATE INDEX IF NOT EXISTS events_geom_idx ON events USING GIST (geom);
+CREATE INDEX IF NOT EXISTS events_time_idx ON events (event_time);
+"""
+
+_UPSERT = """
+INSERT INTO events (event_uid, source, title, link, summary, event_time,
+                    event_type, city, state, country, confidence, simhash, geom)
+VALUES (%(event_uid)s, %(source)s, %(title)s, %(link)s, %(summary)s, %(event_time)s,
+        %(event_type)s, %(city)s, %(state)s, %(country)s, %(confidence)s, %(simhash)s,
+        CASE WHEN %(lon)s IS NOT NULL AND %(lat)s IS NOT NULL
+             THEN ST_SetSRID(ST_MakePoint(%(lon)s, %(lat)s), 4326)
+             ELSE NULL END)
+ON CONFLICT (event_uid) DO UPDATE SET
+    last_seen  = now(),
+    summary    = EXCLUDED.summary,
+    event_time = COALESCE(EXCLUDED.event_time, events.event_time);
+"""
+
+
+def connect(dsn: str):
+    """Return a psycopg2 connection. Raises ImportError if psycopg2 unavailable."""
+    if psycopg2 is None:
+        raise ImportError("psycopg2 is required for PostGIS support. Install psycopg2-binary.")
+    conn = psycopg2.connect(dsn)
+    return conn
+
+
+def ensure_schema(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(SCHEMA_SQL)
+    conn.commit()
+
+
+def upsert_events(conn, rows: List[Dict[str, Any]]) -> int:
+    """Upsert a list of event dicts. Returns count of rows processed."""
+    if not rows:
+        return 0
+    with conn.cursor() as cur:
+        psycopg2.extras.execute_batch(cur, _UPSERT, rows)
+    conn.commit()
+    return len(rows)

--- a/radar/store.py
+++ b/radar/store.py
@@ -1,6 +1,7 @@
 """Storage helpers for DuckDB and SQLite FTS."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Dict
 import sqlite3
 
@@ -8,7 +9,7 @@ import duckdb  # type: ignore[import-not-found]
 import pandas as pd  # type: ignore[import-untyped]
 
 EVENT_COLUMNS = [
-    "id",
+    "event_uid",
     "source",
     "title",
     "link",
@@ -25,72 +26,96 @@ EVENT_COLUMNS = [
 
 
 def connect_duckdb(path: str) -> duckdb.DuckDBPyConnection:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
     conn = duckdb.connect(path)
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS events (
-            id BIGINT,
-            source TEXT,
-            title TEXT,
-            link TEXT,
-            summary TEXT,
-            event_time TIMESTAMP,
-            lat DOUBLE,
-            lon DOUBLE,
-            event_type TEXT,
-            city TEXT,
-            state TEXT,
-            country TEXT,
-            simhash BIGINT
+            event_uid   TEXT PRIMARY KEY,
+            source      TEXT,
+            title       TEXT,
+            link        TEXT,
+            summary     TEXT,
+            event_time  TIMESTAMPTZ,
+            lat         DOUBLE,
+            lon         DOUBLE,
+            event_type  TEXT,
+            city        TEXT,
+            state       TEXT,
+            country     TEXT,
+            simhash     HUGEINT,
+            first_seen  TIMESTAMPTZ DEFAULT now(),
+            last_seen   TIMESTAMPTZ DEFAULT now()
         )
         """
     )
     return conn
 
 
-def insert_events(conn: duckdb.DuckDBPyConnection, rows: List[Dict]) -> List[int]:
+def insert_events(conn: duckdb.DuckDBPyConnection, rows: List[Dict]) -> List[str]:
+    """Upsert events by event_uid; returns list of uids."""
     if not rows:
         return []
-    df = pd.DataFrame(rows, columns=EVENT_COLUMNS[1:])
-    row = conn.execute("SELECT COALESCE(MAX(id), 0) + 1 FROM events").fetchone()
-    start_id = int(row[0]) if row else 1
-    df.insert(0, "id", range(start_id, start_id + len(df)))
-    conn.executemany(
-        "INSERT INTO events VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
-        df.values.tolist(),
-    )
-    return df["id"].tolist()
+    uids = []
+    for row in rows:
+        uid = row["event_uid"]
+        conn.execute(
+            """
+            INSERT INTO events (event_uid, source, title, link, summary, event_time,
+                                lat, lon, event_type, city, state, country, simhash)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (event_uid) DO UPDATE SET
+                last_seen  = now(),
+                summary    = EXCLUDED.summary,
+                event_time = COALESCE(EXCLUDED.event_time, events.event_time)
+            """,
+            [
+                uid,
+                row.get("source"),
+                row.get("title"),
+                row.get("link"),
+                row.get("summary"),
+                row.get("event_time"),
+                row.get("lat"),
+                row.get("lon"),
+                row.get("event_type"),
+                row.get("city"),
+                row.get("state"),
+                row.get("country"),
+                row.get("simhash"),
+            ],
+        )
+        uids.append(uid)
+    return uids
 
 
 def connect_sqlite(path: str) -> sqlite3.Connection:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     cur = conn.cursor()
     cur.execute(
-        "CREATE TABLE IF NOT EXISTS articles (id INTEGER PRIMARY KEY, title TEXT, summary TEXT)"
+        "CREATE TABLE IF NOT EXISTS articles (id TEXT PRIMARY KEY, title TEXT, summary TEXT)"
     )
     cur.execute(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(title, summary, content='articles', content_rowid='id')"
+        "CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(title, summary, content='articles', content_rowid='rowid')"
     )
     conn.commit()
     return conn
 
 
-def upsert_article(conn: sqlite3.Connection, id_: int, title: str, summary: str) -> None:
+def upsert_article(conn: sqlite3.Connection, uid: str, title: str, summary: str) -> None:
     cur = conn.cursor()
     cur.execute(
         "INSERT OR REPLACE INTO articles(id, title, summary) VALUES(?,?,?)",
-        (id_, title, summary),
-    )
-    cur.execute(
-        "INSERT OR REPLACE INTO articles_fts(rowid, title, summary) VALUES(?,?,?)",
-        (id_, title, summary),
+        (uid, title, summary),
     )
     conn.commit()
 
 
-def search_articles(conn: sqlite3.Connection, query: str) -> List[int]:
+def search_articles(conn: sqlite3.Connection, query: str) -> List[str]:
     cur = conn.cursor()
     rows = cur.execute(
-        "SELECT rowid FROM articles_fts WHERE articles_fts MATCH ?", (query,)
+        "SELECT id FROM articles WHERE id IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ?)",
+        (query,),
     ).fetchall()
     return [r[0] for r in rows]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,6 @@ trafilatura
 newspaper3k
 simhash
 streamlit
+pydeck
+psycopg2-binary
 # After install run: python -m spacy download en_core_web_sm

--- a/server.py
+++ b/server.py
@@ -31,7 +31,8 @@ def main() -> None:
 
     # Filters
     min_date, max_date = df["event_time"].min(), df["event_time"].max()
-    start, end = st.sidebar.date_input("Date range", [min_date, max_date])
+    date_range = st.sidebar.date_input("Date range", [min_date, max_date])
+    start, end = (date_range[0], date_range[-1]) if len(date_range) == 2 else (date_range[0], date_range[0])
     sources = st.sidebar.multiselect("Source", df["source"].unique())
     types = st.sidebar.multiselect("Event type", df["event_type"].unique())
     query = st.sidebar.text_input("Text search")
@@ -80,7 +81,7 @@ def main() -> None:
     st.sidebar.write("Last run:", datetime.fromtimestamp(Path(cfg["duckdb_path"]).stat().st_mtime))
     if st.sidebar.button("Run update now"):
         subprocess.run(["python", "ingest.py", "--config", cfg_path, "--update"], check=False)
-        st.experimental_rerun()
+        st.rerun()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restructure ingest pipeline: idempotent upserts, PostGIS backend, tz-aware timestamps

- Replace integer row IDs with stable event_uid (SHA-256 of link/title);
  DuckDB and PostGIS both use ON CONFLICT DO UPDATE so re-runs converge
  instead of accumulating duplicates
- Fix simhash BIGINT overflow: HUGEINT in DuckDB, NUMERIC(20) in PostGIS
- All datetime.utcnow() → datetime.now(timezone.utc); timestamps are now
  tz-aware end-to-end, fixing the --since TypeError and Temporal Controller
- Add radar/pg_store.py: PostGIS schema + upsert_events(); ingest.py routes
  to PostGIS when POSTGIS_DSN env var is set, falls back to DuckDB otherwise
- mkdir before every DB open so cold-start no longer crashes
- Geocode cache key normalized (casefold + strip)
- st.experimental_rerun() → st.rerun(); date_input 1-tuple guard
- Add pydeck, psycopg2-binary to requirements.txt
- GitHub Actions: download en_core_web_sm; pass POSTGIS_DSN secret
- Add __pycache__ and *.sqlite to .gitignore